### PR TITLE
Matrix calculus: Move summation outside of the case

### DIFF
--- a/matrix-calculus/index.html
+++ b/matrix-calculus/index.html
@@ -961,9 +961,9 @@
  	0 & \mathbf{w} \cdot \mathbf{x}_i + b \leq 0\\
  	2(\mathbf{w}\cdot\mathbf{x}_i+b-y_i) & \mathbf{w} \cdot \mathbf{x}_i + b > 0\\
  \end{cases}\\\\
- & = & \begin{cases}
+ & = & \frac{2}{N} \sum_{i=1}^N \begin{cases}
 	0 & \mathbf{w} \cdot \mathbf{x}_i + b \leq 0\\
-	\frac{2}{N} \sum_{i=1}^N (\mathbf{w}\cdot\mathbf{x}_i+b-y_i) & \mathbf{w} \cdot \mathbf{x}_i + b > 0\\
+	\mathbf{w}\cdot\mathbf{x}_i+b-y_i & \mathbf{w} \cdot \mathbf{x}_i + b > 0\\
  \end{cases}
 \end{eqnarray*}
 " url="images/latex-111B8CC26CDC425CE2143E1B38D9B44E.svg"></div>


### PR DESCRIPTION
The derivative is a sum of N vectors, some of which are zero and some of
which are not. Moving the summation inside the piecewise curly brace
makes this unclear. The conditional is decided separately for each i,
and i is only defined inside the summation, so it doesn't really make
sense to move the summation inside the curly brace.